### PR TITLE
Fixed UIView takeScreenshot()

### DIFF
--- a/Source/NavigationStack.swift
+++ b/Source/NavigationStack.swift
@@ -164,7 +164,7 @@ extension UIView {
   func takeScreenshot() -> UIImage {
     
     UIGraphicsBeginImageContextWithOptions(self.bounds.size, false, UIScreen.main.scale)
-    drawHierarchy(in: self.bounds, afterScreenUpdates: true)
+    layer.render(in: UIGraphicsGetCurrentContext()!)
     
     let image = UIGraphicsGetImageFromCurrentImageContext()
     UIGraphicsEndImageContext()


### PR DESCRIPTION
The takeScreenshot() method would not generate a valid screenshot for a UIView. Replacing the call to drawHierarchy() with a layer.render() call fixed the issue for me on iOS 11.