### PR TITLE
Replaced rawgit.com urls with combinatronics.com urls.

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -46,7 +46,7 @@
 <p><a href="http://twitter.com/Ramotion"><img src="https://img.shields.io/badge/Twitter-@Ramotion-blue.svg?style=flat" alt="Twitter"></a>
 <a href="https://cocoapods.org/pods/Navigation-stack"><img src="https://img.shields.io/cocoapods/p/Navigation-stack.svg" alt="CocoaPods"></a>
 <a href="http://cocoapods.org/pods/Navigation-stack"><img src="https://img.shields.io/cocoapods/v/Navigation-stack.svg" alt="CocoaPods"></a>
-<a href="https://cdn.rawgit.com/Ramotion/navigation-stack/master/docs/index.html"><img src="https://img.shields.io/cocoapods/metrics/doc-percent/Navigation-stack.svg" alt="CocoaPods"></a>
+<a href="https://cdn.combinatronics.com/Ramotion/navigation-stack/master/docs/index.html"><img src="https://img.shields.io/cocoapods/metrics/doc-percent/Navigation-stack.svg" alt="CocoaPods"></a>
 <a href="https://travis-ci.org/Ramotion/navigation-stack"><img src="https://img.shields.io/travis/Ramotion/navigation-stack.svg" alt="Travis"></a>
 <a href="https://codebeat.co/projects/github-com-ramotion-navigation-stack"><img src="https://codebeat.co/badges/c322a039-b06b-46d9-bf40-e48cf0365b97" alt="codebeat badge"></a>
 <a href="https://github.com/Ramotion/navigation-stack"><img src="https://img.shields.io/badge/Carthage-compatible-4BC51D.svg?style=flat" alt="Carthage compatible"></a></p>


### PR DESCRIPTION
Combinatronics.com is a drop in replacement for rawgit.com which is EOL.